### PR TITLE
Make widget configs easy to override

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "hogan-express": "^0.5.2",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^2.29.0",
-    "materia-server-client-assets": "^0.3.5",
+    "materia-server-client-assets": "0.3.5",
     "node-sass": "^4.5.3",
     "postcss-loader": "2.0.6",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "hogan-express": "^0.5.2",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^2.29.0",
-    "materia-client-assets": "https://github.com/ucfopen/materia-server-client-assets.git",
+    "materia-server-client-assets": "https://github.com/ucfopen/materia-server-client-assets.git",
     "node-sass": "^4.5.3",
     "postcss-loader": "2.0.6",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "hogan-express": "^0.5.2",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^2.29.0",
-    "materia-server-client-assets": "https://github.com/ucfopen/materia-server-client-assets.git",
+    "materia-server-client-assets": "^0.3.5",
     "node-sass": "^4.5.3",
     "postcss-loader": "2.0.6",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,13 @@
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.11.2",
     "hogan-express": "^0.5.2",
-    "html-loader": "^0.4.5",
+    "html-loader": "^0.5.5",
     "html-webpack-plugin": "^2.29.0",
+<<<<<<< Updated upstream
     "materia-server-client-assets": "0.3.5",
+=======
+    "materia-client-assets": "https://github.com/ucfopen/materia-server-client-assets.git",
+>>>>>>> Stashed changes
     "node-sass": "^4.5.3",
     "postcss-loader": "2.0.6",
     "raw-loader": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,7 @@
     "hogan-express": "^0.5.2",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^2.29.0",
-<<<<<<< Updated upstream
-    "materia-server-client-assets": "0.3.5",
-=======
     "materia-client-assets": "https://github.com/ucfopen/materia-server-client-assets.git",
->>>>>>> Stashed changes
     "node-sass": "^4.5.3",
     "postcss-loader": "2.0.6",
     "raw-loader": "^0.5.1",

--- a/webpack-widget.js
+++ b/webpack-widget.js
@@ -46,6 +46,10 @@ const configFromPackage = () => {
 	}
 }
 
+const configDefaults = () => {
+	
+}
+
 // This is a base config for building legacy widgets
 // It will skip webpack's javascript functionality
 // to avoid having to make changes to the source code of those widgets

--- a/webpack-widget.js
+++ b/webpack-widget.js
@@ -46,28 +46,18 @@ const configFromPackage = () => {
 	}
 }
 
-const configDefaults = () => {
-	
+// Provides a default config option
+const getDefaultCfg = (extras = {}) => {
+	let materiaConfig = configFromPackage()
+	const configs = Object.assign({}, defaultCfg, {cleanName:materiaConfig.cleanName}, extras)
+	return configs
 }
 
-// This is a base config for building legacy widgets
-// It will skip webpack's javascript functionality
-// to avoid having to make changes to the source code of those widgets
-// the config argument allows you to override some settings
-// you can update the return from this method to modify or alter
-// the base configuration
-const getLegacyWidgetBuildConfig = (config = {}) => {
-	// load and combine the config
-	let materiaConfig = configFromPackage()
-	cfg = Object.assign({}, defaultCfg, {cleanName:materiaConfig.cleanName}, config)
-	// set up source and destination paths
+const getDefaultCopyList = () => {
+	cfg = getDefaultCfg()
 	let srcPath = cfg.srcPath + path.sep
 	let outputPath = cfg.outputPath + path.sep
-
-	//standard list of directories/files we want to copy as-is into build
-	let copyList = [
-		//tack on any additional files to copy that were specified by the widget
-		...cfg.preCopy,
+	return [
 		{
 			flatten: true,
 			from: `${srcPath}${cfg.demoPath}`,
@@ -95,18 +85,10 @@ const getLegacyWidgetBuildConfig = (config = {}) => {
 			toType: 'dir'
 		}
 	]
+}	
 
-	//assets directory is not always used, therefore optional - check for it first
-	let assetsPath = `${srcPath}${cfg.assetsPath}`
-	if (fs.existsSync(assetsPath)) {
-		copyList.push({
-			from: assetsPath,
-			to: `${outputPath}assets`,
-			toType: 'dir'
-		})
-	}
-
-	const rules = {
+const getDefaultJSRules = () => {
+	return {
 		// process regular javascript files
 		// SKIPS the default webpack Javascript functionality
 		// that evaluates js code and processes module imports
@@ -220,6 +202,36 @@ const getLegacyWidgetBuildConfig = (config = {}) => {
 			})
 		}
 	}
+}
+
+// This is a base config for building legacy widgets
+// It will skip webpack's javascript functionality
+// to avoid having to make changes to the source code of those widgets
+// the config argument allows you to override some settings
+// you can update the return from this method to modify or alter
+// the base configuration
+const getLegacyWidgetBuildConfig = (config = {}) => {
+	// load and combine the config
+	let cfg = getDefaultCfg(config)
+
+	// set up source and destination paths
+	let srcPath = cfg.srcPath + path.sep
+	let outputPath = cfg.outputPath + path.sep
+
+	//standard list of directories/files we want to copy as-is into build
+	let copyList = getDefaultCopyList()
+
+	//assets directory is not always used, therefore optional - check for it first
+	let assetsPath = `${srcPath}${cfg.assetsPath}`
+	if (fs.existsSync(assetsPath)) {
+		copyList.push({
+			from: assetsPath,
+			to: `${outputPath}assets`,
+			toType: 'dir'
+		})
+	}
+
+	let rules = getDefaultJSRules()
 
 	let plugins = {
 		clean: new CleanPlugin([outputPath]),
@@ -298,4 +310,6 @@ module.exports = {
 	materiaJSReplacements: materiaJSReplacements,
 	configFromPackage: configFromPackage,
 	getLegacyWidgetBuildConfig: getLegacyWidgetBuildConfig,
+	getDefaultJSRules: getDefaultJSRules,
+	getDefaultCopyList: getDefaultCopyList
 }

--- a/webpack-widget.js
+++ b/webpack-widget.js
@@ -128,9 +128,9 @@ const getDefaultCopyList = () => {
 	}
 
 	const devDemo = 'demo_dev.json'
-	const devDemoPath = `${srcPath}demo.json`
+	const devDemoPath = `${srcPath}${devDemo}`
 	if (isRunningDevServer && fs.existsSync(devDemoPath)) {
-		console.log('===== USING demo_dev.json ====')
+		console.log(`===== USING ${devDemo} ====`)
 		copyList.push({
 			flatten: true,
 			from: devDemoPath,

--- a/webpack-widget.js
+++ b/webpack-widget.js
@@ -49,8 +49,7 @@ const configFromPackage = () => {
 // Provides a default config option
 const getDefaultCfg = (extras = {}) => {
 	let materiaConfig = configFromPackage()
-	const configs = Object.assign({}, defaultCfg, {cleanName:materiaConfig.cleanName}, extras)
-	return configs
+	return Object.assign({}, defaultCfg, {cleanName:materiaConfig.cleanName}, extras)
 }
 
 const getDefaultCopyList = () => {
@@ -87,7 +86,7 @@ const getDefaultCopyList = () => {
 	]
 }	
 
-const getDefaultJSRules = () => {
+const getDefaultRules = () => {
 	return {
 		// process regular javascript files
 		// SKIPS the default webpack Javascript functionality
@@ -231,7 +230,7 @@ const getLegacyWidgetBuildConfig = (config = {}) => {
 		})
 	}
 
-	let rules = getDefaultJSRules()
+	let rules = getDefaultRules()
 
 	let plugins = {
 		clean: new CleanPlugin([outputPath]),
@@ -310,6 +309,6 @@ module.exports = {
 	materiaJSReplacements: materiaJSReplacements,
 	configFromPackage: configFromPackage,
 	getLegacyWidgetBuildConfig: getLegacyWidgetBuildConfig,
-	getDefaultJSRules: getDefaultJSRules,
+	getDefaultRules: getDefaultRules,
 	getDefaultCopyList: getDefaultCopyList
 }

--- a/webpack-widget.js
+++ b/webpack-widget.js
@@ -27,6 +27,11 @@ const browserList = [
 	'last 3 Safari versions',
 	'last 3 Edge versions'
 ]
+
+const copyIgnore = [
+	'.gitkeep'
+]
+
 const materiaJSReplacements = [
 	{ search: /src=(\\?("|')?)(materia.enginecore.js)(\\?("|')?)/g,  replace: replaceTarget },
 	{ search: /src=(\\?("|')?)(materia.scorecore.js)(\\?("|')?)/g,   replace: replaceTarget },
@@ -271,7 +276,7 @@ const getLegacyWidgetBuildConfig = (config = {}) => {
 			// clear the build directory
 			new CleanPlugin([outputPath]),
 			// copy all the common resources to the build directory
-			new CopyPlugin(cfg.copyList),
+			new CopyPlugin(cfg.copyList, {ignore: copyIgnore}),
 			// extract css from the webpack output
 			new ExtractTextPlugin({filename: '[name]'}),
 			// zip everything in the build path to zip dir

--- a/yarn.lock
+++ b/yarn.lock
@@ -4915,9 +4915,9 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-"materia-server-client-assets@https://github.com/ucfopen/materia-server-client-assets.git":
+materia-server-client-assets@0.3.5:
   version "0.3.5"
-  resolved "https://github.com/ucfopen/materia-server-client-assets.git#286c518635985aac6edb9db5038a25862f55c434"
+  resolved "https://registry.yarnpkg.com/materia-server-client-assets/-/materia-server-client-assets-0.3.5.tgz#fc0f8daaff537b2c4279d54d9f9d98ca5dfd59b4"
   dependencies:
     angular "1.6.9"
     angular-mocks "1.6.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,6 +1491,12 @@ clean-css@4.1.x:
   dependencies:
     source-map "0.5.x"
 
+clean-css@4.2.x:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17"
+  dependencies:
+    source-map "~0.6.0"
+
 clean-webpack-plugin@^0.1.16:
   version "0.1.16"
   resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-0.1.16.tgz#422a8e150bf3d5abfd3d14bfacb070e80fb2e23f"
@@ -1664,6 +1670,10 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
 commander@2.11.x, commander@~2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
+commander@2.17.x, commander@~2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
 
 commander@^2.14.1, commander@^2.9.0:
   version "2.15.1"
@@ -2487,7 +2497,7 @@ es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbo
     d "1"
     es5-ext "~0.10.14"
 
-es6-templates@^0.2.2:
+es6-templates@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/es6-templates/-/es6-templates-0.2.3.tgz#5cb9ac9fb1ded6eb1239342b81d792bbb4078ee4"
   dependencies:
@@ -3441,17 +3451,17 @@ html-entities@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
 
-html-loader@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/html-loader/-/html-loader-0.4.5.tgz#5fbcd87cd63a5c49a7fce2fe56f425e05729c68c"
+html-loader@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/html-loader/-/html-loader-0.5.5.tgz#6356dbeb0c49756d8ebd5ca327f16ff06ab5faea"
   dependencies:
-    es6-templates "^0.2.2"
+    es6-templates "^0.2.3"
     fastparse "^1.1.1"
-    html-minifier "^3.0.1"
-    loader-utils "^1.0.2"
-    object-assign "^4.1.0"
+    html-minifier "^3.5.8"
+    loader-utils "^1.1.0"
+    object-assign "^4.1.1"
 
-html-minifier@^3.0.1, html-minifier@^3.2.3:
+html-minifier@^3.2.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.3.tgz#4a275e3b1a16639abb79b4c11191ff0d0fcf1ab9"
   dependencies:
@@ -3463,6 +3473,18 @@ html-minifier@^3.0.1, html-minifier@^3.2.3:
     param-case "2.1.x"
     relateurl "0.2.x"
     uglify-js "3.0.x"
+
+html-minifier@^3.5.8:
+  version "3.5.20"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.20.tgz#7b19fd3caa0cb79f7cde5ee5c3abdf8ecaa6bb14"
+  dependencies:
+    camel-case "3.0.x"
+    clean-css "4.2.x"
+    commander "2.17.x"
+    he "1.1.x"
+    param-case "2.1.x"
+    relateurl "0.2.x"
+    uglify-js "3.4.x"
 
 html-webpack-plugin@^2.29.0:
   version "2.29.0"
@@ -4893,9 +4915,15 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+<<<<<<< Updated upstream
 materia-server-client-assets@0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/materia-server-client-assets/-/materia-server-client-assets-0.3.5.tgz#fc0f8daaff537b2c4279d54d9f9d98ca5dfd59b4"
+=======
+"materia-client-assets@https://github.com/ucfopen/materia-server-client-assets.git":
+  version "0.3.5"
+  resolved "https://github.com/ucfopen/materia-server-client-assets.git#286c518635985aac6edb9db5038a25862f55c434"
+>>>>>>> Stashed changes
   dependencies:
     angular "1.6.9"
     angular-mocks "1.6.9"
@@ -5702,7 +5730,7 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -7489,7 +7517,7 @@ source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.6.0, source-map@~0.6.1:
+source-map@^0.6.0, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -7994,6 +8022,13 @@ uglify-js@3.0.x:
   dependencies:
     commander "~2.11.0"
     source-map "~0.5.1"
+
+uglify-js@3.4.x:
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.9.tgz#af02f180c1207d76432e473ed24a28f4a782bae3"
+  dependencies:
+    commander "~2.17.1"
+    source-map "~0.6.1"
 
 uglify-js@^2.6, uglify-js@^2.8.29:
   version "2.8.29"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4915,15 +4915,9 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-<<<<<<< Updated upstream
-materia-server-client-assets@0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/materia-server-client-assets/-/materia-server-client-assets-0.3.5.tgz#fc0f8daaff537b2c4279d54d9f9d98ca5dfd59b4"
-=======
 "materia-client-assets@https://github.com/ucfopen/materia-server-client-assets.git":
   version "0.3.5"
   resolved "https://github.com/ucfopen/materia-server-client-assets.git#286c518635985aac6edb9db5038a25862f55c434"
->>>>>>> Stashed changes
   dependencies:
     angular "1.6.9"
     angular-mocks "1.6.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4915,7 +4915,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-"materia-client-assets@https://github.com/ucfopen/materia-server-client-assets.git":
+"materia-server-client-assets@https://github.com/ucfopen/materia-server-client-assets.git":
   version "0.3.5"
   resolved "https://github.com/ucfopen/materia-server-client-assets.git#286c518635985aac6edb9db5038a25862f55c434"
   dependencies:
@@ -5272,7 +5272,7 @@ neo-async@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.1.tgz#acb909e327b1e87ec9ef15f41b8a269512ad41ee"
 
-"ngmodal@github:ucfcdl/ngModal#v1.2.2":
+ngmodal@ucfcdl/ngModal#v1.2.2:
   version "1.2.2"
   resolved "https://codeload.github.com/ucfcdl/ngModal/tar.gz/6abad982bdb8f258ffcdc20316a907c2292399d2"
 


### PR DESCRIPTION
Moves some widget configurations out of `getLegacyWidgetBuildConfig`, allowing them to be more easily referenced/overridden: 
- The default copyList is returned via `getDefaultCopyList()`, which can be modified, appended, and used to override the copyList sent to the copyPlugin by default.
- JS rules have been encapsulated into their own object allowing them to be individually referenced, modified, or removed.
- Plugins have also been moved into an object allowing individual steps to be changed.