### PR TITLE
Default widget metadata values if needed.

### DIFF
--- a/express.js
+++ b/express.js
@@ -138,6 +138,10 @@ var createApiWidgetInstanceData = id => {
 var createApiWidgetData = (id) => {
 	let widget = yaml.parse(getInstall().toString());
 
+	//provide default values where necessary
+	if ( ! widget.meta_data.features) widget.meta_data.features = [];
+	if ( ! widget.meta_data.supported_data) widget.meta_data.features = [];
+
 	widget.player = widget.files.player;
 	widget.creator = widget.files.creator;
 	widget.clean_name = getWidgetCleanName();


### PR DESCRIPTION
Closes #15.

MWDK provides default for some widget metadata values that the frontend code is expecting to be non-null.