### PR TITLE
Whitelists MWDK in node_modules for SASS loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Materia Widget Development Kit (MWDK) is a local dev environment for quickly building Materia Widgets.",
   "license": "AGPL-3.0",
   "homepage": "https://ucfopen.github.io/Materia-Docs/",
-  "version": "2.4.1",
+  "version": "2.4.2-alpha1",
   "author": "University of Central Florida, Center for Distributed Learning",
   "scripts": {
     "build": "webpack",

--- a/webpack-widget.js
+++ b/webpack-widget.js
@@ -247,7 +247,7 @@ const getDefaultRules = () => ({
 	// Adds autoprefixer
 	loadAndPrefixSASS: {
 		test: /\.s[ac]ss$/i,
-		exclude: /node_modules/,
+		exclude: /node_modules\/(?!(materia-widget-development-kit\/templates)\/).*/,
 		loader: ExtractTextPlugin.extract({
 			use: [
 				'raw-loader',


### PR DESCRIPTION
Fixes issue with the helper-docs sass file not getting run through the `loadAndPrefixSASS` rule.

To test, blow away your `node_modules` and set MWDK to `2.4.2-alpha1`