### PR TITLE
Fix GenerateWidgetHash plugin

### DIFF
--- a/views/score_mwdk.hbs
+++ b/views/score_mwdk.hbs
@@ -1,7 +1,6 @@
 <link rel="stylesheet" href="/mwdk/assets/css/mwdk-download.css" type="text/css" />
 <link href='//fonts.googleapis.com/css?family=Lato:300,400,700|Droid+Sans+Mono' rel='stylesheet' type='text/css'>
 <link rel='stylesheet' href='/mwdk/assets/css/mwdk-main.css' type='text/css' />
-<link rel='stylesheet' href='/mwdk/assets/css/mwdk-scorescreen.css' type='text/css' />
 <link rel="stylesheet" href="/materia-assets/css/scores.css" type="text/css" />
 
 <script type="text/javascript" src="/materia-assets/js/materia.enginecore.js"></script>

--- a/webpack-generate-widget-hash.js
+++ b/webpack-generate-widget-hash.js
@@ -37,10 +37,10 @@ class GenerateWidgetHash {
 
 				// get some build environment information
 				var date = new Date()
-				var gitCommit = 'unkown'
-				var email = 'unkown'
-				var user = 'unkown'
-				var gitRemote = 'unkown'
+				var gitCommit = 'unknown'
+				var email = 'unknown'
+				var user = 'unknown'
+				var gitRemote = 'unknown'
 
 				try {
 					gitCommit = execSync('git rev-parse HEAD').toString()


### PR DESCRIPTION
The build info yaml file is currently not being emitted from webpack, which is required for installation in Materia.

The GenerateWidgetHash plugin is using a Webpack 4 method for hooking into the compilation. It is also using the synchronous `tap` method to process assets, so the function to emit the .yml asset is never called. Furthermore, the stage `PROCESS_ASSETS_STAGE_ADDITIONAL` is run before `PROCESS_ASSETS_STAGE_OPTIMIZE_TRANSFER`, which is what the ZipPlugin uses to create the `.wigt` file. I changed it to use the last stage, `PROCESS_ASSETS_STAGE_REPORT`, which is when assets are created for reporting purposes.

I've left a commented-out section for debugging purposes.