### PR TITLE
Custom loader to fix Materia scripts replacement rule

### DIFF
--- a/materia-scripts-loader.js
+++ b/materia-scripts-loader.js
@@ -12,7 +12,7 @@ module.exports = function(source) {
 	// Define replacement patterns
 	const packagedJSPath = 'src="../../../js/$3"'
 	const devServerJSPath = 'src="/materia-assets/js/$3"'
-	const replaceTarget = isRunningDevServer ? devServerJSPath : packagedJSPath;
+	const replaceTarget = isRunningDevServer ? devServerJSPath : packagedJSPath
 
 	// Perform replacements
 	let result = source

--- a/materia-scripts-loader.js
+++ b/materia-scripts-loader.js
@@ -1,0 +1,24 @@
+// materia-scripts-loader.js
+
+/**
+ * Custom HTML loader that replaces Materia script references
+ * @param {string} source - The HTML source code
+ * @returns {string} - The processed HTML
+ */
+module.exports = function(source) {
+	// Get webpack loader context
+	const isRunningDevServer = process.env.NODE_ENV !== "production"
+
+	// Define replacement patterns
+	const packagedJSPath = 'src="../../../js/$3"'
+	const devServerJSPath = 'src="/materia-assets/js/$3"'
+	const replaceTarget = isRunningDevServer ? devServerJSPath : packagedJSPath;
+
+	// Perform replacements
+	let result = source
+		.replace(/src=(\\?("|')?)(materia.enginecore.js)(\\?("|')?)/g, replaceTarget)
+		.replace(/src=(\\?("|')?)(materia.scorecore.js)(\\?("|')?)/g, replaceTarget)
+		.replace(/src=(\\?("|')?)(materia.creatorcore.js)(\\?("|')?)/g, replaceTarget)
+
+	return `module.exports = ${JSON.stringify(result)}`
+}

--- a/webpack-widget.js
+++ b/webpack-widget.js
@@ -205,16 +205,8 @@ const getDefaultRules = () => ({
 		test: /\.html$/i,
 		exclude: /node_modules|_guides|guides/,
 		use: [
-			{
-				loader: 'html-loader',
-				options: {
-					sources: false
-				}
-			},
-			{
-				loader: 'string-replace-loader',
-				options: { multiple: materiaJSReplacements }
-			},
+			// process the HTML and return it as a module
+			path.resolve(__dirname, 'materia-scripts-loader.js')
 		]
 	},
 	// Process SASS/SCSS/CSS Files


### PR DESCRIPTION
Adds `materia-scripts-loader` as an independent JS module. The loader works as a replacement for `html-loader` and `string-replace-loader` to conditionally replace Materia scripts in HTML. This correction to the core widget-webpack config means webpack configs for individual widgets do not need to be updated.