### PR TITLE
Dodge fatal score screen errors.

### DIFF
--- a/express.js
+++ b/express.js
@@ -1683,8 +1683,13 @@ app.get('/api/play-sessions/:instance/', (req, res) => {
 app.get('/api/scores/details/', async (req, res) => {
 	res.set('Content-Type', 'application/json')
 
-	let id = 'demo';
-	id = req.query.play_id
+	const id = req.query.play_id
+
+	// make sure we actually have a play log file, or we get catastrophic errors
+	const logFilePath = path.join(qsets, `${id}-log.json`)
+	if (!fs.existsSync(logFilePath)) {
+		return res.status(500).json([])
+	}
 
 	if (id == null) {
 		return res.json([])

--- a/views/score_mwdk.hbs
+++ b/views/score_mwdk.hbs
@@ -35,38 +35,6 @@
 	</div>
 </div>
 
-<div id="warning">
-    <h2>SCORESCREEN INSTRUCTIONS</h2>
-    <p>If you have finished the score_module, you may upload a JSON file containing sample play score data to design your custom <code>scorescreen.html</code>. <i id="how-do-i" onclick="MWDK.Package.toggleJSONInstructions();">How do I find the score data?</i></p>
-	<div class="json-instructions">
-		<p>The score data is returned by Materia in the <code>widget_instance_play_scores_get</code> request after processing and scoring the play logs using <code>score_module.py/php</code>. For how to retrieve this score data, use this guide: </p>
-		<ol>
-			<li>Install and run <a href="https://github.com/ucfopen/Materia">Materia</a>.</li>
-			<li>Click <strong>Download Package</strong> and <strong>Install to Docker Materia</strong></li>
-			<li>Open your widget in Materia.</li>
-			<li>Open your browser's developer tools (<code>Command + Option + i</code> on Mac, <code>Ctrl + Shift + i</code> on Windows) and go to the Network tab.</li>
-			<li>Play the widget until you reach the scorescreen.</li>
-			<li>Once you've reached the scorescreen, look for a request to <code>widget_instance_play_scores_get</code> and click it.</li>
-			<li>Go to the Response tab, right click on the JSON object, and click <code>Copy All</code>. Alternatively, right click on the request and click Copy Value -> Copy Response.</li>
-			<li>Create a JSON file on your computer and paste the response data.</li>
-			<li>Upload the file here.</li>
-		</ol>
-	</div>
-	<div class="file-upload">
-		<label for="fileUpload">Sample Play Score Data</label>
-		<input id="fileUpload" type="file" accept=".json" onchange="MWDK.Package.showUploadButton();"/>
-		<button id="upload-button" disabled="true" onclick="MWDK.Package.uploadScoreData();">Upload</button>
-		<button  class="edit_button action_button smaller" onclick="MWDK.Package.removeScoreData();">Remove Sample Play Score Data</button>
-		</br>
-	</div>
-	<div class="remove-logs">
-		<button class="edit_button action_button smaller" onclick="MWDK.Package.removePlayLogs();">Clear Play Logs</button>
-		<p>This will remove any leftover play logs from this session. Do this if you're experiencing issues displaying the sample score data.</p>
-	</div>
-    <p><strong>Disclaimer</strong>: There is currently no support for scoring play sessions with <code>score_module.py/php</code> in the Materia Widget Development Kit, so scoring may not be accurate, especially for widgets with custom scorescreens. Use this tool only for designing how the data is displayed: you must install the widget in Materia to test the <code>score_module.py/php</code>.</p>
-	<p id="message"></p>
-</div>
-
 <div id="app"></div>
 <div id='modalbg'></div>
 


### PR DESCRIPTION
Removing page elements from score screen that are no longer necessary, adding a step to check for a given play log before trying to use it to dodge fatal errors in the backend.