### PR TITLE
Support dark mode in guide pages.

### DIFF
--- a/express.js
+++ b/express.js
@@ -24,7 +24,7 @@ const webpackConfLocation  = fs.existsSync(wpConfCjsLocation) ? wpConfCjsLocatio
 const webpack              = require('webpack');
 const webpackDevMiddleware = require('webpack-dev-middleware');
 const config               = require(webpackConfLocation);
-const compiler = webpack(config);
+const compiler             = webpack(config);
 
 
 const webpackMiddleware = webpackDevMiddleware(compiler, {
@@ -457,6 +457,10 @@ const verifyInstallProp = (prop, desiredType = null) => {
 	return true
 }
 
+const guideExists = playerOrCreator => {
+	return !!getFileFromWebpack(`guides/${playerOrCreator}.html`)
+}
+
 // BEGIN PYODIDE CODE
 
 let py = null
@@ -511,6 +515,12 @@ const port = process.env.PORT || 8118;
 // ============= ASSETS and SETUP =======================
 
 hbs.registerPartials(__dirname + 'views/partials', function(err) {});
+hbs.registerHelper('or', function(arg1, arg2, options) {
+	if (arg1 || arg2) {
+		return options.fn(this)
+	}
+	return options.inverse(this)
+});
 hbs.localsAsTemplateData(app);
 
 app.set('views', path.join(__dirname , 'views/')); // set the views directory
@@ -560,7 +570,12 @@ app.use( (req, res, next) => {
 
 // Display index page
 app.get('/', (req, res) => {
-	res.locals = Object.assign(res.locals, {template: 'index', title: getWidgetTitle()})
+	res.locals = Object.assign(res.locals, {
+		template: 'index',
+		title: getWidgetTitle(),
+		hasPlayerGuide: guideExists('player'),
+		hasCreatorGuide: guideExists('creator')
+	})
 	res.render(res.locals.template)
 });
 
@@ -756,8 +771,8 @@ app.get('/mwdk/widgets/1-mwdk/creators-guide', (req, res) => {
 		template: 'guide_page',
 		name: '1-mwdk',
 		type: 'creator',
-		hasPlayerGuide: true,
-		hasCreatorGuide: true,
+		hasPlayerGuide: guideExists('player'),
+		hasCreatorGuide: guideExists('creator'),
 		docPath: '/guides/creator.html',
 		instance: req.params.hash || 'demo'
 	})
@@ -769,8 +784,8 @@ app.get('/mwdk/widgets/1-mwdk/players-guide', (req, res) => {
 		template: 'guide_page',
 		name: '1-mwdk',
 		type: 'player',
-		hasPlayerGuide: true,
-		hasCreatorGuide: true,
+		hasPlayerGuide: guideExists('player'),
+		hasCreatorGuide: guideExists('creator'),
 		docPath: '/guides/player.html',
 		instance: req.params.hash || 'demo'
 	})
@@ -1730,6 +1745,10 @@ except Exception :
 })
 app.get('/api/scores/details', (req, res) => {
 	console.log('generic scores api endpoint')
+})
+
+app.get('/api/site-messages', (req, res) => {
+	return res.json({})
 })
 
 app.listen(port, function () {

--- a/src/mwdk.guidehack.js
+++ b/src/mwdk.guidehack.js
@@ -1,0 +1,9 @@
+Namespace('MWDK').GuideHack = (() => {
+	const handleGuideToggleDarkMode = () => {
+		document.getElementById('guide-container').getElementsByTagName('iframe')[0].contentWindow.document.body.classList.toggle('darkMode')
+	}
+
+	return {
+		handleGuideToggleDarkMode: handleGuideToggleDarkMode
+	}
+})()

--- a/templates/guideStyles.css
+++ b/templates/guideStyles.css
@@ -8,10 +8,24 @@ body {
 	padding: 10px;
 
 	font-family: 'Lato', arial, serif;
+
+	--main-header-color: #333333;
+	--secondary-header-color: #5e5e5e;
+	--paragraph-color: #000;
+}
+
+body.darkMode {
+	background-color: #21232a;
+	/* catch any text not explicitly given a color */
+	color: var(--paragraph-color);
+
+	--main-header-color: #c7c7c7;
+	--secondary-header-color: #c7c7c7;
+	--paragraph-color: #fff;
 }
 
 h1, h2, h3, h4 {
-	color: #333333;
+	color: var(--main-header-color);
 	word-break: break-word;
 }
 
@@ -24,13 +38,13 @@ h1 {
 }
 
 h3 {
-	color: #5e5e5e;
+	color: var(--secondary-header-color);
 	font-size: 18px;
 }
 
 h4, h5, h6 {
 	font-size: 16px;
-	color: #5e5e5e;
+	color: var(--secondary-header-color);
 }
 
 img + h2,
@@ -65,7 +79,7 @@ table code {
 }
 
 p {
-	color: black;
+	color: var(--paragraph-color);
 	font-size: 16px;
 }
 

--- a/views/guide_page.hbs
+++ b/views/guide_page.hbs
@@ -11,6 +11,7 @@
 <script src="/materia-assets/js/materia.enginecore.js"></script>
 
 <script src="/mwdk/mwdk-assets/js/mwdk-package.js"></script>
+<script src='/mwdk/mwdk-assets/js/mwdk-guidehack.js'></script>
 
 <script >
 	var WIDGET_HEIGHT = '600';
@@ -26,11 +27,17 @@
     var HAS_PLAYER_GUIDE = '{{ hasPlayerGuide }}'
     var HAS_CREATOR_GUIDE = '{{ hasCreatorGuide }}'
     var DOC_PATH = '{{ docPath }}'
+	var IS_EMBEDDED = true
 </script>
 
 <div id="topbar">
 	<a class="logo" href="/">Materia Widget Developer Kit</a>
 	<div class="tools">
+		<button
+			class="action_button"
+			onclick="MWDK.GuideHack.handleGuideToggleDarkMode();">
+			Toggle Dark Mode
+		</button>
 		<button class="edit_button action_button" onclick="MWDK.Package.showPlayer();">Player</button>
 		<button id="downloadLink" class="edit_button action_button" onclick="MWDK.Package.showPackageDownload();">Download Package</button>
 	</div>

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -12,6 +12,17 @@
 		{{!-- <a id='creator_button' onclick='location.href="/mwdk/widgets/1-mwdk/create/";'><button class='action_button bigger edit_button'>Creator</button></a> --}}
 		<a id='creator_button' href="/mwdk/widgets/1-mwdk/create/?is_embedded=true"><button class='action_button bigger edit_button'>Creator</button></a>
 		<a id='score_button' onclick='location.href="/mwdk/scores/embed/demo/demo";'><button class='action_button bigger edit_button'>Scorescreen</button></a>
+
+		{{#or hasPlayerGuide hasCreatorGuide}}
+			<h5>Guides</h5>
+			{{#if hasPlayerGuide }}
+				<a id='guide_button' class='helper-button' href='/mwdk/widgets/1-mwdk/players-guide'><button class='edit_button'>Player Guide</button></a>
+			{{/if}}
+			{{#if hasCreatorGuide }}
+				<a id='guide_button' class='helper-button' href='/mwdk/widgets/1-mwdk/creators-guide'><button class='edit_button'>Creator Guide</button></a>
+			{{/if}}
+		{{/or}}
+
 		<h5>Additional Tools</h5>
 		<a id='annotation-button' class='helper-button' href='/mwdk/helper/annotations'><button class='edit_button'>Annotate Screenshots</button></a>
 		<a id='icons_button' class='helper-button' href='/mwdk/icons/'><button class='edit_button'>Generate Icons</button></a>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,9 @@ module.exports =
 			],
 			'mwdk-helpers.js': [
 				path.join(srcPath, 'mwdk.helpers.js')
+			],
+			'mwdk-guidehack.js': [
+				path.join(srcPath, 'mwdk.guidehack.js')
 			]
 		},
 


### PR DESCRIPTION
Closes #165.

Adds a convenience function in express backend to identify whether player/creator guides actually exist instead of just assuming they do.
Adds a Handlebars helper function in express backend to enable 'or' conditionals in the views.
Adds view code to splash page to make shortcuts to player/creator guides if they exist.
Adds support to guide page view to quickly toggle dark mode on the embedded guide.
Adds super bare bones dark mode color changes to default guide page CSS rules.

Doesn't explicitly require it but will look a lot less janky after ucfopen/Materia#1769.