### PR TITLE
Adds node and yarn version requirements.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "homepage": "https://ucfopen.github.io/Materia-Docs/",
   "version": "3.0.5",
   "author": "University of Central Florida, Center for Distributed Learning",
+  "engines": {
+    "node": ">=24.18.0 <25.0.0",
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.22.0"
+  },
   "scripts": {
     "build": "webpack",
     "mwdk-start": "./bin/mwdk-start.js",


### PR DESCRIPTION
Closes #168.

Adds version requirements for Node and `yarn`.

Everything appears to work as-is otherwise.